### PR TITLE
Add config file again 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ First install the  [Nova](https://nova.laravel.com) package via composer:
 ```bash
 composer require christophrumpel/nova-notifications
 ```
+Then publish the config file(optional):
+ ``` bash
+php artisan vendor:publish --provider="Christophrumpel\NovaNotifications\ToolServiceProvider"
+```
+ In there, you can define where to look for the Notification classes, as well as the notifiable models.
+ ```php
+ <?php
+ return [
+     /*
+      * The namespaces you want to check for Notification classes.
+      */
+     'notifiableNamespaces' => [
+         'App',
+     ],
+     /*
+      * The namespaces you want to check for Notifiable classes.
+      */
+     'notificationNamespaces' => [
+         'App\Notifications',
+         'Illuminate',
+     ],
+ ];
+ ```
+ 
 
 Next up, you must register the tool via the `tools` method of the `NovaServiceProvider`.
 

--- a/config/nova-notifications.php
+++ b/config/nova-notifications.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     /*
      * The namespaces you want to check for Notification classes.

--- a/config/nova-notifications.php
+++ b/config/nova-notifications.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    /*
+     * The namespaces you want to check for Notification classes.
+     */
+    'notifiableNamespaces' => [
+        'App',
+    ],
+    /*
+     * The namespaces you want to check for Notifiable classes.
+     */
+    'notificationNamespaces' => [
+        'App\Notifications',
+        'Illuminate',
+    ],
+];

--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -1442,7 +1442,7 @@ exports = module.exports = __webpack_require__(1)(false);
 
 
 // module
-exports.push([module.i, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n/* Scoped Styles */\n", ""]);
+exports.push([module.i, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n/* Scoped Styles */\n", ""]);
 
 // exports
 
@@ -1548,6 +1548,10 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
     methods: {
         selectNotification: function selectNotification(notification) {
+            if (!this.notifiables.data.length) {
+                return this.$toasted.show('No notifiables could be found.', { type: 'error' });
+            }
+
             this.selectedNotification = notification;
         },
         deselectNotification: function deselectNotification() {

--- a/resources/js/components/NotificationsSend.vue
+++ b/resources/js/components/NotificationsSend.vue
@@ -86,6 +86,10 @@
         },
         methods: {
             selectNotification(notification) {
+                if(!this.notifiables.data.length) {
+                    return this.$toasted.show('No notifiables could be found.', {type: 'error'});
+                }
+                
                 this.selectedNotification = notification;
             },
             deselectNotification() {

--- a/src/Http/Controllers/NotifiableController.php
+++ b/src/Http/Controllers/NotifiableController.php
@@ -24,7 +24,7 @@ class NotifiableController extends ApiController
 
     public function index()
     {
-        $modelClasses = $this->classFinder->findByExtending('Illuminate\Database\Eloquent\Model')
+        $modelClasses = $this->classFinder->findByExtending('Illuminate\Database\Eloquent\Model', config('nova-notifications.notifiableNamespaces'))
             ->filter(function ($className) {
                 $classInfo = new ReflectionClass($className);
 

--- a/src/Http/Controllers/NotificationClassesController.php
+++ b/src/Http/Controllers/NotificationClassesController.php
@@ -34,7 +34,7 @@ class NotificationClassesController extends ApiController
                 } catch (\ReflectionException $e) {
                     return [
                         'name' => $className,
-                        'parameters' => []
+                        'parameters' => [],
                     ];
                 }
 
@@ -42,7 +42,6 @@ class NotificationClassesController extends ApiController
                 $notificationClassInfo->name = $classInfo->class;
 
                 $params = collect($classInfo->getParameters())->map(function (ReflectionParameter $param) {
-
                     $paramTypeName = is_null($param->getType()) ? 'unknown' : $param->getType()
                         ->getName();
 

--- a/src/Http/Controllers/NotificationClassesController.php
+++ b/src/Http/Controllers/NotificationClassesController.php
@@ -27,14 +27,23 @@ class NotificationClassesController extends ApiController
 
     public function index()
     {
-        return $this->classFinder->findByExtending('Illuminate\Notifications\Notification')
+        return $this->classFinder->findByExtending('Illuminate\Notifications\Notification', config('nova-notifications.notificationNamespaces'))
             ->map(function ($className) {
-                $classInfo = new ReflectionMethod($className, '__construct');
+                try {
+                    $classInfo = new ReflectionMethod($className, '__construct');
+                } catch (\ReflectionException $e) {
+                    return [
+                        'name' => $className,
+                        'parameters' => []
+                    ];
+                }
+
                 $notificationClassInfo = new stdClass();
                 $notificationClassInfo->name = $classInfo->class;
 
                 $params = collect($classInfo->getParameters())->map(function (ReflectionParameter $param) {
-                    $paramTypeName = $param->getType()
+
+                    $paramTypeName = is_null($param->getType()) ? 'unknown' : $param->getType()
                         ->getName();
 
                     if (class_exists($paramTypeName)) {
@@ -53,8 +62,7 @@ class NotificationClassesController extends ApiController
 
                     return [
                         'name' => $param->getName(),
-                        'type' => $param->getType()
-                            ->getName(),
+                        'type' => $paramTypeName,
                         'options' => $options ?? '',
                     ];
                 });

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -19,6 +19,10 @@ class ToolServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-notifications');
 
         $this->publishes([
+            __DIR__.'/../config/nova-notifications.php' => config_path('nova-notifications.php'),
+        ], 'config');
+
+        $this->publishes([
             __DIR__.'/../resources/lang' => resource_path('lang/vendor/nova-notifications'),
         ], 'nova-notifications-lang');
 
@@ -74,6 +78,6 @@ class ToolServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->mergeConfigFrom(__DIR__.'/../config/nova-notifications.php', 'nova-notifications');
     }
 }

--- a/tests/Controllers/NotifiableControllerTest.php
+++ b/tests/Controllers/NotifiableControllerTest.php
@@ -16,8 +16,7 @@ class NotifiableControllerTest extends TestCase
         $this->app->instance(ClassFinder::class, $classFinder);
 
         $classFinder->shouldReceive('findByExtending')
-            ->withArgs(['Illuminate\Database\Eloquent\Model'])
-            ->andReturn(collect([]));
+            ->withArgs(['Illuminate\Database\Eloquent\Model', ['App']])            ->andReturn(collect([]));
 
         $response = $this->get('nova-vendor/nova-notifications/notifiables')
             ->assertSuccessful();
@@ -37,7 +36,7 @@ class NotifiableControllerTest extends TestCase
         $this->app->instance(ClassFinder::class, $classFinder);
 
         $classFinder->shouldReceive('findByExtending')
-            ->withArgs(['Illuminate\Database\Eloquent\Model'])
+            ->withArgs(['Illuminate\Database\Eloquent\Model', ['App']])
             ->andReturn(collect([$testModelClassName]));
 
         $this->get('nova-vendor/nova-notifications/notifiables')

--- a/tests/Controllers/NotifiableControllerTest.php
+++ b/tests/Controllers/NotifiableControllerTest.php
@@ -16,7 +16,8 @@ class NotifiableControllerTest extends TestCase
         $this->app->instance(ClassFinder::class, $classFinder);
 
         $classFinder->shouldReceive('findByExtending')
-            ->withArgs(['Illuminate\Database\Eloquent\Model', ['App']])            ->andReturn(collect([]));
+            ->withArgs(['Illuminate\Database\Eloquent\Model', ['App']])
+            ->andReturn(collect([]));
 
         $response = $this->get('nova-vendor/nova-notifications/notifiables')
             ->assertSuccessful();

--- a/tests/Controllers/NotificationClassesControllerTest.php
+++ b/tests/Controllers/NotificationClassesControllerTest.php
@@ -29,7 +29,7 @@ class NotificationClassesControllerTest extends TestCase
     public function it_returns_given_notification_classes()
     {
         $this->classFinder->shouldReceive('findByExtending')
-            ->withArgs(['Illuminate\Notifications\Notification'])
+            ->withArgs(['Illuminate\Notifications\Notification', config('nova-notifications.notificationNamespaces')])
             ->andReturn(collect([$this->testNotificationClassName]));
 
         $this->get('nova-vendor/nova-notifications/notifications/classes')


### PR DESCRIPTION
This PR 
* adds the config file again to define namespaces to look for notifiable and notification classes
* it also shows an error trying to open the modal for sending a notification when there was not notifiable class found.