### PR TITLE
ClassFinder: Fix issue with old string helper methods

### DIFF
--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Collection;
 class ClassFinder
 {
     /**
-     * @return mixedt
+     * @return mixed
      */
     public function getNamespace()
     {

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -2,14 +2,14 @@
 
 namespace Christophrumpel\NovaNotifications;
 
-use Illuminate\Support\Str;
 use ReflectionClass;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 
 class ClassFinder
 {
     /**
-     * @return mixed
+     * @return mixedt
      */
     public function getNamespace()
     {

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -2,6 +2,7 @@
 
 namespace Christophrumpel\NovaNotifications;
 
+use Illuminate\Support\Str;
 use ReflectionClass;
 use Illuminate\Support\Collection;
 
@@ -24,7 +25,7 @@ class ClassFinder
         $composer = require base_path('vendor/autoload.php');
 
         return collect($composer->getClassMap())->filter(function ($value, $key) use ($nameSpace) {
-            return starts_with($key, $nameSpace);
+            return Str::startsWith($key, $nameSpace);
         });
     }
 
@@ -47,7 +48,7 @@ class ClassFinder
             ->filter(function ($className) use ($namespacesToSearch) {
                 return collect($namespacesToSearch)
                     ->filter(function ($namespace) use ($className) {
-                        return starts_with($className, $namespace);
+                        return Str::startsWith($className, $namespace);
                     })
                     ->count();
             })

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -62,4 +62,5 @@ class ClassFinder
                 return $classInfo->isSubclassOf($classNameToFind);
             });
     }
+    
 }

--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -62,5 +62,4 @@ class ClassFinder
                 return $classInfo->isSubclassOf($classNameToFind);
             });
     }
-    
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Christophrumpel\NovaNotifications\Tests;
+namespace Christophrumpel\NovaNotifications\tests;
 
 use Christophrumpel\NovaNotifications\ClassFinder;
 
@@ -33,5 +33,4 @@ class ClassFinderTest extends TestCase
 
         $this->assertInstanceOf('Illuminate\Support\Collection', $response);
     }
-
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -33,4 +33,5 @@ class ClassFinderTest extends TestCase
 
         $this->assertInstanceOf('Illuminate\Support\Collection', $response);
     }
+
 }

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -11,7 +11,7 @@ class ClassFinderTest extends TestCase
      **/
     public function it_find_classes()
     {
-        $this->app->setBasePath(__DIR__ .'/..');
+        $this->app->setBasePath(__DIR__.'/..');
 
         $classFinder = app(ClassFinder::class);
 
@@ -25,7 +25,7 @@ class ClassFinderTest extends TestCase
      **/
     public function it_find_classes_which_are_extending_a_specific_class()
     {
-        $this->app->setBasePath(__DIR__ . '/..');
+        $this->app->setBasePath(__DIR__.'/..');
 
         $classFinder = app(ClassFinder::class);
 

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -3,7 +3,6 @@
 namespace Christophrumpel\NovaNotifications\Tests;
 
 use Christophrumpel\NovaNotifications\ClassFinder;
-use Mockery;
 
 class ClassFinderTest extends TestCase
 {
@@ -12,7 +11,7 @@ class ClassFinderTest extends TestCase
      **/
     public function it_find_classes()
     {
-        $this->app->setBasePath(__DIR__ . '/..');
+        $this->app->setBasePath(__DIR__ .'/..');
 
         $classFinder = app(ClassFinder::class);
 

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Christophrumpel\NovaNotifications\Tests;
+
+use Christophrumpel\NovaNotifications\ClassFinder;
+use Mockery;
+
+class ClassFinderTest extends TestCase
+{
+    /**
+     * @test
+     **/
+    public function it_find_classes()
+    {
+        $this->app->setBasePath(__DIR__ . '/..');
+
+        $classFinder = app(ClassFinder::class);
+
+        $response = $classFinder->find('Illuminate\Database\Eloquent\Model', ['App']);
+
+        $this->assertInstanceOf('Illuminate\Support\Collection', $response);
+    }
+
+    /**
+     * @test
+     **/
+    public function it_find_classes_which_are_extending_a_specific_class()
+    {
+        $this->app->setBasePath(__DIR__ . '/..');
+
+        $classFinder = app(ClassFinder::class);
+
+        $response = $classFinder->findByExtending('Illuminate\Database\Eloquent\Model', ['App']);
+
+        $this->assertInstanceOf('Illuminate\Support\Collection', $response);
+    }
+}


### PR DESCRIPTION
When using the package with Laravel 6, the string helper methods in ClassFinder are deprecated causing the Send Notification screen to break when viewed in Nova. 

This PR provides fixes to the ClassFinder method and two unit tests to check the find and findByExisting methods return a collection as expected.

The controller tests mocked the ClassFinder methods so it wasn't able to pick up the string helper changes to the framework.